### PR TITLE
Conditionally compile references to UIApplication only when not building for an extension target

### DIFF
--- a/JXHTTP.podspec
+++ b/JXHTTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'JXHTTP'
-  s.version       = '1.0.4'
+  s.version       = '1.0.5'
   s.source_files  = 'JXHTTP/*.{h,m}'
   s.homepage      = 'http://justinouellette.com'
   s.summary       = 'Networking for iOS and OS X.'

--- a/JXHTTP/JXOperation.m
+++ b/JXHTTP/JXOperation.m
@@ -11,7 +11,7 @@
 @property (assign) dispatch_queue_t stateQueue;
 #endif
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !__has_feature(attribute_availability_app_extension)
 @property (assign) UIBackgroundTaskIdentifier backgroundTaskID;
 #endif
 
@@ -41,7 +41,7 @@
         self.isFinished = NO;
         self.continuesInAppBackground = NO;
         
-        #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+        #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !__has_feature(attribute_availability_app_extension)
         self.backgroundTaskID = UIBackgroundTaskInvalid;
         #endif
     }
@@ -127,7 +127,7 @@
 
 - (void)startAppBackgroundTask
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !__has_feature(attribute_availability_app_extension)
     
     if (self.backgroundTaskID != UIBackgroundTaskInvalid || [self isCancelled])
         return;
@@ -153,7 +153,7 @@
 
 - (void)endAppBackgroundTask
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !__has_feature(attribute_availability_app_extension)
     
     UIBackgroundTaskIdentifier taskID = self.backgroundTaskID;
     if (taskID == UIBackgroundTaskInvalid)


### PR DESCRIPTION
Provides better support for CocoaPods 0.36 which builds static libraries using the same compiler flags as the target being compiled for.