### PR TITLE
App extension compatibility

### DIFF
--- a/JXHTTP.podspec
+++ b/JXHTTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'JXHTTP'
-  s.version       = '1.0.7'
+  s.version       = '2.0.0'
   s.source_files  = 'JXHTTP/*.{h,m}'
   s.homepage      = 'http://justinouellette.com'
   s.summary       = 'Networking for iOS and OS X.'

--- a/JXHTTP/JXBackgroundTaskManager.h
+++ b/JXHTTP/JXBackgroundTaskManager.h
@@ -6,10 +6,25 @@
 //  Copyright (c) 2015 JXHTTP. All rights reserved.
 //
 
+/**
+ A protocol that classes who can begin and end background tasks can conform to. This protocol provides an abstraction in 
+ order to avoid referencing `+ [UIApplication sharedApplication]` from within an iOS application extension.
+ */
 @protocol JXBackgroundTaskManager <NSObject>
 
+/**
+ Marks the beginning of a new long-running background task.
+ 
+ @return A unique identifier for the new background task. You must pass this value to the `endBackgroundTask:` method to 
+ mark the end of this task. This method returns `UIBackgroundTaskInvalid` if running in the background is not possible.
+ */
 - (UIBackgroundTaskIdentifier)beginBackgroundTask;
 
+/**
+ Marks the end of a specific long-running background task.
+ 
+ @param identifier An identifier returned by the `beginBackgroundTaskWithExpirationHandler:` method.
+ */
 - (void)endBackgroundTask:(UIBackgroundTaskIdentifier)identifier;
 
 @end

--- a/JXHTTP/JXBackgroundTaskManager.h
+++ b/JXHTTP/JXBackgroundTaskManager.h
@@ -1,0 +1,15 @@
+//
+//  JXBackgroundTaskManager.h
+//  JXExample
+//
+//  Created by Bryan Irace on 4/24/15.
+//  Copyright (c) 2015 JXHTTP. All rights reserved.
+//
+
+@protocol JXBackgroundTaskManager <NSObject>
+
+- (UIBackgroundTaskIdentifier)beginBackgroundTask;
+
+- (void)endBackgroundTask:(UIBackgroundTaskIdentifier)identifier;
+
+@end

--- a/JXHTTP/JXHTTPOperation.h
+++ b/JXHTTP/JXHTTPOperation.h
@@ -296,6 +296,11 @@ typedef NSURLRequest * (^JXHTTPRedirectBlock)(JXHTTPOperation *operation, NSURLR
 
 /// @name Network activity indication
 
+/**
+ Set a global manager to be used for showing or hiding the network activity indicator.
+ 
+ @param networkActivityIndicatorManager Network activity indicator manager manager.
+ */
 + (void)setNetworkActivityIndicatorManager:(id <JXNetworkActivityIndicatorManager>)networkActivityIndicatorManager;
 
 @end

--- a/JXHTTP/JXHTTPOperation.h
+++ b/JXHTTP/JXHTTPOperation.h
@@ -39,6 +39,7 @@
 #import "JXURLConnectionOperation.h"
 #import "JXHTTPOperationDelegate.h"
 #import "JXHTTPRequestBody.h"
+@protocol JXNetworkActivityIndicatorManager;
 
 typedef void (^JXHTTPBlock)(JXHTTPOperation *operation);
 typedef NSCachedURLResponse * (^JXHTTPCacheBlock)(JXHTTPOperation *operation, NSCachedURLResponse *response);
@@ -292,5 +293,9 @@ typedef NSURLRequest * (^JXHTTPRedirectBlock)(JXHTTPOperation *operation, NSURLR
  @returns An operation.
  */
 + (instancetype)withURLString:(NSString *)urlString queryParameters:(NSDictionary *)parameters;
+
+/// @name Network activity indication
+
++ (void)setNetworkActivityIndicatorManager:(id <JXNetworkActivityIndicatorManager>)networkActivityIndicatorManager;
 
 @end

--- a/JXHTTP/JXHTTPOperation.m
+++ b/JXHTTP/JXHTTPOperation.m
@@ -1,11 +1,13 @@
 #import "JXHTTPOperation.h"
+#import "JXNetworkActivityIndicatorManager.h"
 #import "JXURLEncoding.h"
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0 && defined(__clang) && defined(__has_feature) && !__has_feature(attribute_availability_app_extension)
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
 
 static NSUInteger JXHTTPOperationCount = 0;
 static NSTimer * JXHTTPActivityTimer = nil;
 static NSTimeInterval JXHTTPActivityTimerInterval = 0.25;
+static id <JXNetworkActivityIndicatorManager> JXHTTPNetworkActivityIndicatorManager;
 
 #endif
 
@@ -170,16 +172,17 @@ static NSTimeInterval JXHTTPActivityTimerInterval = 0.25;
 
 - (void)incrementOperationCount
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0 && defined(__clang) && defined(__has_feature) && !__has_feature(attribute_availability_app_extension)
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
     
     dispatch_once(&_incrementCountOnce, ^{
-        if (!self.updatesNetworkActivityIndicator)
+        if (!(self.updatesNetworkActivityIndicator && JXHTTPNetworkActivityIndicatorManager))
             return;
 
         dispatch_async(dispatch_get_main_queue(), ^{
             ++JXHTTPOperationCount;
             [JXHTTPActivityTimer invalidate];
-            [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
+            
+            JXHTTPNetworkActivityIndicatorManager.networkActivityIndicatorVisible = YES;
         });
 
         self.didIncrementCount = YES;
@@ -190,13 +193,13 @@ static NSTimeInterval JXHTTPActivityTimerInterval = 0.25;
 
 - (void)decrementOperationCount
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0 && defined(__clang) && defined(__has_feature) && !__has_feature(attribute_availability_app_extension)
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
     
     if (!self.didIncrementCount)
         return;
     
     dispatch_once(&_decrementCountOnce, ^{
-        if (!self.updatesNetworkActivityIndicator)
+        if (!(self.updatesNetworkActivityIndicator && JXHTTPNetworkActivityIndicatorManager))
             return;
 
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -210,7 +213,7 @@ static NSTimeInterval JXHTTPActivityTimerInterval = 0.25;
 
 + (void)restartActivityTimer
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0 && defined(__clang) && defined(__has_feature) && !__has_feature(attribute_availability_app_extension)
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
     
     JXHTTPActivityTimer = [NSTimer timerWithTimeInterval:JXHTTPActivityTimerInterval
                                                   target:self
@@ -225,9 +228,9 @@ static NSTimeInterval JXHTTPActivityTimerInterval = 0.25;
 
 + (void)networkActivityTimerDidFire:(NSTimer *)timer
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0 && defined(__clang) && defined(__has_feature) && !__has_feature(attribute_availability_app_extension)
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
 
-    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+    JXHTTPNetworkActivityIndicatorManager.networkActivityIndicatorVisible = NO;
     
     #endif
 }
@@ -465,6 +468,12 @@ static NSTimeInterval JXHTTPActivityTimerInterval = 0.25;
         [self cancel];
 
     return [self isCancelled] ? nil : modifiedRequest;
+}
+
+#pragma mark - Network activity indication
+
++ (void)setNetworkActivityIndicatorManager:(id <JXNetworkActivityIndicatorManager>)networkActivityIndicatorManager {
+    JXHTTPNetworkActivityIndicatorManager = networkActivityIndicatorManager;
 }
 
 @end

--- a/JXHTTP/JXHTTPOperation.m
+++ b/JXHTTP/JXHTTPOperation.m
@@ -7,9 +7,10 @@
 static NSUInteger JXHTTPOperationCount = 0;
 static NSTimer * JXHTTPActivityTimer = nil;
 static NSTimeInterval JXHTTPActivityTimerInterval = 0.25;
-static id <JXNetworkActivityIndicatorManager> JXHTTPNetworkActivityIndicatorManager;
 
 #endif
+
+static id <JXNetworkActivityIndicatorManager> JXHTTPNetworkActivityIndicatorManager;
 
 @interface JXHTTPOperation ()
 @property (assign) BOOL didIncrementCount;

--- a/JXHTTP/JXNetworkActivityIndicatorManager.h
+++ b/JXHTTP/JXNetworkActivityIndicatorManager.h
@@ -8,6 +8,6 @@
 
 @protocol JXNetworkActivityIndicatorManager <NSObject>
 
-@property (nonatomic, getter=isNetworkActivityIndicatorVisible) BOOL networkActivityIndicatorVisible;
+@property (nonatomic) BOOL networkActivityIndicatorVisible;
 
 @end

--- a/JXHTTP/JXNetworkActivityIndicatorManager.h
+++ b/JXHTTP/JXNetworkActivityIndicatorManager.h
@@ -1,0 +1,13 @@
+//
+//  JXNetworkActivityIndicatorManager.h
+//  JXExample
+//
+//  Created by Bryan Irace on 4/24/15.
+//  Copyright (c) 2015 JXHTTP. All rights reserved.
+//
+
+@protocol JXNetworkActivityIndicatorManager <NSObject>
+
+@property (nonatomic, getter=isNetworkActivityIndicatorVisible) BOOL networkActivityIndicatorVisible;
+
+@end

--- a/JXHTTP/JXNetworkActivityIndicatorManager.h
+++ b/JXHTTP/JXNetworkActivityIndicatorManager.h
@@ -6,8 +6,16 @@
 //  Copyright (c) 2015 JXHTTP. All rights reserved.
 //
 
+/**
+ A protocol that classes who can toggle the network activity visibility indicator can conform to. This protocol provides 
+ an abstraction in order to avoid referencing `+ [UIApplication sharedApplication]` from within an iOS application 
+ extension.
+ */
 @protocol JXNetworkActivityIndicatorManager <NSObject>
 
+/**
+ A Boolean value that turns an indicator of network activity on or off.
+ */
 @property (nonatomic) BOOL networkActivityIndicatorVisible;
 
 @end

--- a/JXHTTP/JXOperation.h
+++ b/JXHTTP/JXOperation.h
@@ -87,6 +87,11 @@
 
 /// @name Background task management
 
+/**
+ Set a global manager to be used for setting up/tearing down any background tasks needed by JXHTTP.
+ 
+ @param backgroundTaskManager Background task manager.
+ */
 + (void)setBackgroundTaskManager:(id <JXBackgroundTaskManager>)backgroundTaskManager;
 
 @end

--- a/JXHTTP/JXOperation.h
+++ b/JXHTTP/JXOperation.h
@@ -1,3 +1,5 @@
+@protocol JXBackgroundTaskManager;
+
 /**
  `JXOperation` is an abstract `NSOperation` subclass that implements all the
  methods necessary for what Apple calls "concurrent" operations. See the sections
@@ -51,6 +53,8 @@
  have no effect. Changing it to `NO` will discontinue background execution.
  */
 @property (assign) BOOL continuesInAppBackground;
+
+@property (nonatomic) id <JXBackgroundTaskManager> backgroundTaskManager;
 
 /// @name Starting & Finishing
 

--- a/JXHTTP/JXOperation.h
+++ b/JXHTTP/JXOperation.h
@@ -54,8 +54,6 @@
  */
 @property (assign) BOOL continuesInAppBackground;
 
-@property (nonatomic) id <JXBackgroundTaskManager> backgroundTaskManager;
-
 /// @name Starting & Finishing
 
 /**
@@ -86,5 +84,9 @@
  different thread.
  */
 - (void)finish;
+
+/// @name Background task management
+
++ (void)setBackgroundTaskManager:(id <JXBackgroundTaskManager>)backgroundTaskManager;
 
 @end

--- a/JXHTTP/JXOperation.m
+++ b/JXHTTP/JXOperation.m
@@ -1,6 +1,8 @@
 #import "JXBackgroundTaskManager.h"
 #import "JXOperation.h"
 
+static id <JXBackgroundTaskManager> JXHTTPBackgroundTaskManager;
+
 @interface JXOperation ()
 
 @property (assign) BOOL isExecuting;
@@ -124,12 +126,16 @@
     [tempQueue waitUntilAllOperationsAreFinished];
 }
 
-#pragma mark - Private Methods
+#pragma mark - Background task management
+
++ (void)setBackgroundTaskManager:(id <JXBackgroundTaskManager>)backgroundTaskManager {
+    JXHTTPBackgroundTaskManager = backgroundTaskManager;
+}
 
 - (void)startAppBackgroundTask
 {
     #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
-    if (self.backgroundTaskManager) {
+    if (JXHTTPBackgroundTaskManager) {
         if (self.backgroundTaskID != UIBackgroundTaskInvalid || [self isCancelled])
             return;
         
@@ -141,7 +147,7 @@
             if (!strongSelf || [strongSelf isCancelled] || strongSelf.isFinished)
                 return;
 
-            strongSelf.backgroundTaskID = [strongSelf.backgroundTaskManager beginBackgroundTask];
+            strongSelf.backgroundTaskID = [JXHTTPBackgroundTaskManager beginBackgroundTask];
         });
     }
     #endif
@@ -150,7 +156,7 @@
 - (void)endAppBackgroundTask
 {
     #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
-    if (self.backgroundTaskManager) {
+    if (JXHTTPBackgroundTaskManager) {
         UIBackgroundTaskIdentifier taskID = self.backgroundTaskID;
         if (taskID == UIBackgroundTaskInvalid)
             return;
@@ -158,7 +164,7 @@
         self.backgroundTaskID = UIBackgroundTaskInvalid;
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self.backgroundTaskManager endBackgroundTask:taskID];
+            [JXHTTPBackgroundTaskManager endBackgroundTask:taskID];
         });
     }
     #endif

--- a/JXHTTP/JXOperation.m
+++ b/JXHTTP/JXOperation.m
@@ -14,7 +14,7 @@ static id <JXBackgroundTaskManager> JXHTTPBackgroundTaskManager;
 @property (assign) dispatch_queue_t stateQueue;
 #endif
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
 @property (assign) UIBackgroundTaskIdentifier backgroundTaskID;
 #endif
 
@@ -44,7 +44,7 @@ static id <JXBackgroundTaskManager> JXHTTPBackgroundTaskManager;
         self.isFinished = NO;
         self.continuesInAppBackground = NO;
         
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
         self.backgroundTaskID = UIBackgroundTaskInvalid;
     #endif
     }
@@ -134,7 +134,7 @@ static id <JXBackgroundTaskManager> JXHTTPBackgroundTaskManager;
 
 - (void)startAppBackgroundTask
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
     if (JXHTTPBackgroundTaskManager) {
         if (self.backgroundTaskID != UIBackgroundTaskInvalid || [self isCancelled])
             return;
@@ -155,7 +155,7 @@ static id <JXBackgroundTaskManager> JXHTTPBackgroundTaskManager;
 
 - (void)endAppBackgroundTask
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
     if (JXHTTPBackgroundTaskManager) {
         UIBackgroundTaskIdentifier taskID = self.backgroundTaskID;
         if (taskID == UIBackgroundTaskInvalid)

--- a/JXHTTP/JXOperation.m
+++ b/JXHTTP/JXOperation.m
@@ -1,3 +1,4 @@
+#import "JXBackgroundTaskManager.h"
 #import "JXOperation.h"
 
 @interface JXOperation ()
@@ -11,7 +12,7 @@
 @property (assign) dispatch_queue_t stateQueue;
 #endif
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && defined(__clang) && defined(__has_feature) && !__has_feature(attribute_availability_app_extension)
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
 @property (assign) UIBackgroundTaskIdentifier backgroundTaskID;
 #endif
 
@@ -41,9 +42,9 @@
         self.isFinished = NO;
         self.continuesInAppBackground = NO;
         
-        #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && defined(__clang) && defined(__has_feature) && !__has_feature(attribute_availability_app_extension)
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
         self.backgroundTaskID = UIBackgroundTaskInvalid;
-        #endif
+    #endif
     }
     return self;
 }
@@ -127,44 +128,39 @@
 
 - (void)startAppBackgroundTask
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && defined(__clang) && defined(__has_feature) && !__has_feature(attribute_availability_app_extension)
-    
-    if (self.backgroundTaskID != UIBackgroundTaskInvalid || [self isCancelled])
-        return;
-    
-    __weak __typeof(self) weakSelf = self;
-    
-    dispatch_async(dispatch_get_main_queue(), ^{
-        __typeof(weakSelf) strongSelf = weakSelf;
-
-        if (!strongSelf || [strongSelf isCancelled] || strongSelf.isFinished)
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
+    if (self.backgroundTaskManager) {
+        if (self.backgroundTaskID != UIBackgroundTaskInvalid || [self isCancelled])
             return;
+        
+        __weak __typeof(self) weakSelf = self;
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            __typeof(weakSelf) strongSelf = weakSelf;
+            
+            if (!strongSelf || [strongSelf isCancelled] || strongSelf.isFinished)
+                return;
 
-        UIBackgroundTaskIdentifier taskID = UIBackgroundTaskInvalid;
-        taskID = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
-            [[UIApplication sharedApplication] endBackgroundTask:taskID];
-        }];
-
-        strongSelf.backgroundTaskID = taskID;
-    });
-
+            strongSelf.backgroundTaskID = [strongSelf.backgroundTaskManager beginBackgroundTask];
+        });
+    }
     #endif
 }
 
 - (void)endAppBackgroundTask
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && defined(__clang) && defined(__has_feature) && !__has_feature(attribute_availability_app_extension)
-    
-    UIBackgroundTaskIdentifier taskID = self.backgroundTaskID;
-    if (taskID == UIBackgroundTaskInvalid)
-        return;
-    
-    self.backgroundTaskID = UIBackgroundTaskInvalid;
-    
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[UIApplication sharedApplication] endBackgroundTask:taskID];
-    });
-
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
+    if (self.backgroundTaskManager) {
+        UIBackgroundTaskIdentifier taskID = self.backgroundTaskID;
+        if (taskID == UIBackgroundTaskInvalid)
+            return;
+        
+        self.backgroundTaskID = UIBackgroundTaskInvalid;
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.backgroundTaskManager endBackgroundTask:taskID];
+        });
+    }
     #endif
 }
 

--- a/example/JXExample.xcodeproj/project.pbxproj
+++ b/example/JXExample.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		93E151C61AEA8B3C00CCD447 /* JXBackgroundTaskManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JXBackgroundTaskManager.h; sourceTree = "<group>"; };
+		93E151C71AEA8CDA00CCD447 /* JXNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JXNetworkActivityIndicatorManager.h; sourceTree = "<group>"; };
 		D04867A316EE75E000473908 /* JXHTTP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JXHTTP.h; sourceTree = "<group>"; };
 		D04867A416EE75E000473908 /* JXHTTPDataBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JXHTTPDataBody.h; sourceTree = "<group>"; };
 		D04867A516EE75E000473908 /* JXHTTPDataBody.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JXHTTPDataBody.m; sourceTree = "<group>"; };
@@ -109,6 +111,8 @@
 				D04867BA16EE75E000473908 /* JXURLConnectionOperation.m */,
 				D04867BB16EE75E000473908 /* JXURLEncoding.h */,
 				D04867BC16EE75E000473908 /* JXURLEncoding.m */,
+				93E151C61AEA8B3C00CCD447 /* JXBackgroundTaskManager.h */,
+				93E151C71AEA8CDA00CCD447 /* JXNetworkActivityIndicatorManager.h */,
 			);
 			name = JXHTTP;
 			path = ../../JXHTTP;


### PR DESCRIPTION
Turns out my [previous](https://github.com/jstn/JXHTTP/pull/11) [attempt](https://github.com/jstn/JXHTTP/pull/9) at this – conditional compilation – was misguided. Instead, let’s just remove background task creation and network activity indicators from this library altogether and provide a way for applications to hook-in and provide it themselves.