### PR TITLE
Drop OS X support in order to simplify

### DIFF
--- a/JXHTTP.podspec
+++ b/JXHTTP.podspec
@@ -6,12 +6,11 @@ Pod::Spec.new do |s|
   s.summary       = 'Networking for iOS and OS X.'
   s.authors       = { 'Justin Ouellette' => 'justin.ouellette@gmail.com',
                       'Bryan Irace' => 'bryan.irace@gmail.com' }
+  s.platform      = :ios, '5.0'
   s.source        = { :git => 'https://github.com/jstn/JXHTTP.git', :tag => "#{s.version}" }
   s.license       = { :type => 'MIT', :file => 'LICENSE.txt' }
   s.requires_arc  = true
   s.frameworks    = 'Foundation'
   s.ios.weak_frameworks   = 'UIKit'
-  s.osx.weak_frameworks   = 'AppKit'
   s.ios.deployment_target = '5.0'
-  s.osx.deployment_target = '10.7'
 end

--- a/JXHTTP/JXHTTPOperation.m
+++ b/JXHTTP/JXHTTPOperation.m
@@ -2,13 +2,9 @@
 #import "JXNetworkActivityIndicatorManager.h"
 #import "JXURLEncoding.h"
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
-
 static NSUInteger JXHTTPOperationCount = 0;
 static NSTimer * JXHTTPActivityTimer = nil;
 static NSTimeInterval JXHTTPActivityTimerInterval = 0.25;
-
-#endif
 
 static id <JXNetworkActivityIndicatorManager> JXHTTPNetworkActivityIndicatorManager;
 
@@ -173,8 +169,6 @@ static id <JXNetworkActivityIndicatorManager> JXHTTPNetworkActivityIndicatorMana
 
 - (void)incrementOperationCount
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
-    
     dispatch_once(&_incrementCountOnce, ^{
         if (!(self.updatesNetworkActivityIndicator && JXHTTPNetworkActivityIndicatorManager))
             return;
@@ -188,14 +182,10 @@ static id <JXNetworkActivityIndicatorManager> JXHTTPNetworkActivityIndicatorMana
 
         self.didIncrementCount = YES;
     });
-    
-    #endif
 }
 
 - (void)decrementOperationCount
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
-    
     if (!self.didIncrementCount)
         return;
     
@@ -208,14 +198,10 @@ static id <JXNetworkActivityIndicatorManager> JXHTTPNetworkActivityIndicatorMana
                 [JXHTTPOperation restartActivityTimer];
         });
     });
-
-    #endif
 }
 
 + (void)restartActivityTimer
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
-    
     JXHTTPActivityTimer = [NSTimer timerWithTimeInterval:JXHTTPActivityTimerInterval
                                                   target:self
                                                 selector:@selector(networkActivityTimerDidFire:)
@@ -223,17 +209,11 @@ static id <JXNetworkActivityIndicatorManager> JXHTTPNetworkActivityIndicatorMana
                                                  repeats:NO];
     
     [[NSRunLoop mainRunLoop] addTimer:JXHTTPActivityTimer forMode:NSRunLoopCommonModes];
-
-    #endif
 }
 
 + (void)networkActivityTimerDidFire:(NSTimer *)timer
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
-
     JXHTTPNetworkActivityIndicatorManager.networkActivityIndicatorVisible = NO;
-    
-    #endif
 }
 
 #pragma mark - Accessors

--- a/JXHTTP/JXOperation.m
+++ b/JXHTTP/JXOperation.m
@@ -14,9 +14,7 @@ static id <JXBackgroundTaskManager> JXHTTPBackgroundTaskManager;
 @property (assign) dispatch_queue_t stateQueue;
 #endif
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
 @property (assign) UIBackgroundTaskIdentifier backgroundTaskID;
-#endif
 
 @end
 
@@ -44,9 +42,7 @@ static id <JXBackgroundTaskManager> JXHTTPBackgroundTaskManager;
         self.isFinished = NO;
         self.continuesInAppBackground = NO;
         
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
         self.backgroundTaskID = UIBackgroundTaskInvalid;
-    #endif
     }
     return self;
 }
@@ -134,7 +130,6 @@ static id <JXBackgroundTaskManager> JXHTTPBackgroundTaskManager;
 
 - (void)startAppBackgroundTask
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
     if (JXHTTPBackgroundTaskManager) {
         if (self.backgroundTaskID != UIBackgroundTaskInvalid || [self isCancelled])
             return;
@@ -150,12 +145,10 @@ static id <JXBackgroundTaskManager> JXHTTPBackgroundTaskManager;
             strongSelf.backgroundTaskID = [JXHTTPBackgroundTaskManager beginBackgroundTask];
         });
     }
-    #endif
 }
 
 - (void)endAppBackgroundTask
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
     if (JXHTTPBackgroundTaskManager) {
         UIBackgroundTaskIdentifier taskID = self.backgroundTaskID;
         if (taskID == UIBackgroundTaskInvalid)
@@ -167,7 +160,6 @@ static id <JXBackgroundTaskManager> JXHTTPBackgroundTaskManager;
             [JXHTTPBackgroundTaskManager endBackgroundTask:taskID];
         });
     }
-    #endif
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # JXHTTP #
 
-JXHTTP is a networking library for iOS and OS X. It leverages operation queues and GCD to provide a powerful wrapper for Cocoa's built-in `NSURLConnection` object, adding many useful features like block response objects and progress tracking across multiple requests. It strives to be as lightweight and readable as possible, making it easy to use or customize for advanced behavior.
+JXHTTP is a networking library for iOS. It leverages operation queues and GCD to provide a powerful wrapper for Cocoa's built-in `NSURLConnection` object, adding many useful features like block response objects and progress tracking across multiple requests. It strives to be as lightweight and readable as possible, making it easy to use or customize for advanced behavior.
 
 To get started, simply [download the latest tag](https://github.com/jstn/JXHTTP/tags) and drop the `JXHTTP` folder into your Xcode project. There are zero external dependencies or special compiler flags, just `#import "JXHTTP.h"` somewhere convenient. A complete docset is included for use in Xcode or [Dash](http://kapeli.com/dash/), and available online at [jxhttp.com](http://jxhttp.com/docs/html/). JXHTTP is also available as a [CocoaPod](http://cocoapods.org/?q=name%3AJXHTTP).
 
-JXHTTP requires iOS 5.0 or OS X 10.7 or newer.
+JXHTTP requires iOS 5.0 or newer.
 
 ## Advantages ##
 


### PR DESCRIPTION
This library is in maintenance mode at this point and should be simplified where possible. If anyone is already using this on OS X, they can continue using whatever 1.X.X version they’re currently using. If looking for something new, it should be something more modern/well-maintained than JXHTTP.